### PR TITLE
Add FileRepository.new_filename uniqueness test

### DIFF
--- a/tests/metagpt/utils/test_file_repository.py
+++ b/tests/metagpt/utils/test_file_repository.py
@@ -7,6 +7,7 @@
 @Desc: Unit tests for file_repository.py
 """
 import shutil
+import time
 from pathlib import Path
 
 import pytest
@@ -33,14 +34,24 @@ async def test_file_repo():
     assert file_repo.workdir == full_path
     assert file_repo.workdir.exists()
     await file_repo.save("a.txt", "AAA")
-    await file_repo.save("b.txt", "BBB", [str(full_path / "a.txt"), f"{file_repo_path}/c.txt"])
+    await file_repo.save(
+        "b.txt", "BBB", [str(full_path / "a.txt"), f"{file_repo_path}/c.txt"]
+    )
     doc = await file_repo.get("a.txt")
     assert "AAA" == doc.content
     doc = await file_repo.get("b.txt")
     assert "BBB" == doc.content
-    assert {f"{file_repo_path}/a.txt", f"{file_repo_path}/c.txt"} == await file_repo.get_dependency("b.txt")
-    assert {"a.txt": ChangeType.UNTRACTED, "b.txt": ChangeType.UNTRACTED} == file_repo.changed_files
-    assert {f"{file_repo_path}/a.txt"} == await file_repo.get_changed_dependency("b.txt")
+    assert {
+        f"{file_repo_path}/a.txt",
+        f"{file_repo_path}/c.txt",
+    } == await file_repo.get_dependency("b.txt")
+    assert {
+        "a.txt": ChangeType.UNTRACTED,
+        "b.txt": ChangeType.UNTRACTED,
+    } == file_repo.changed_files
+    assert {f"{file_repo_path}/a.txt"} == await file_repo.get_changed_dependency(
+        "b.txt"
+    )
     await file_repo.save("d/e.txt", "EEE")
     assert ["d/e.txt"] == file_repo.get_change_dir_files("d")
     assert set(file_repo.all_files) == {"a.txt", "b.txt", "d/e.txt"}
@@ -51,6 +62,16 @@ async def test_file_repo():
     assert set(file_repo.all_files) == {"a.txt"}
 
     git_repo.delete_repository()
+
+
+def test_new_filename_unique():
+    """Ensure FileRepository.new_filename produces unique values."""
+    from metagpt.utils.file_repository import FileRepository
+
+    name1 = FileRepository.new_filename()
+    time.sleep(1)
+    name2 = FileRepository.new_filename()
+    assert name1 != name2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add test for FileRepository.new_filename uniqueness

## Testing
- `ruff check tests/metagpt/utils/test_file_repository.py`
- `black tests/metagpt/utils/test_file_repository.py`
- `isort tests/metagpt/utils/test_file_repository.py`
- `pytest tests/metagpt/utils/test_file_repository.py::test_new_filename_unique -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6851aaa6c068832ba64bae37ee7d8655