### PR TITLE
Add UUID suffix to new_filename

### DIFF
--- a/metagpt/utils/file_repository.py
+++ b/metagpt/utils/file_repository.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime
+import uuid
 from pathlib import Path
 from typing import Dict, List, Set
 
@@ -182,12 +183,12 @@ class FileRepository:
 
     @staticmethod
     def new_filename():
-        """Generate a new filename based on the current timestamp and a UUID suffix.
+        """Generate a new filename using the current timestamp and a unique UUID.
 
-        :return: A new filename string.
+        :return: A new filename string in the format ``YYYYMMDDHHMMSS_<uuid>``.
         """
         current_time = datetime.now().strftime("%Y%m%d%H%M%S")
-        return current_time
+        return f"{current_time}_{uuid.uuid4().hex}"
 
     async def save_doc(self, doc: Document, dependencies: List[str] = None):
         """Save content to a file and update its dependencies.


### PR DESCRIPTION
## Summary
- generate filenames with timestamp plus a UUID

## Testing
- `ruff check metagpt/utils/file_repository.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6851aab35008832b91e240c69e97f26a