### PR TITLE
Fix decorator typo in registry

### DIFF
--- a/metagpt/actions/action_outcls_registry.py
+++ b/metagpt/actions/action_outcls_registry.py
@@ -15,7 +15,7 @@ def register_action_outcls(func):
     """
 
     @wraps(func)
-    def decorater(*args, **kwargs):
+    def decorator(*args, **kwargs):
         """
         arr example
             [<class 'metagpt.actions.action_node.ActionNode'>, 'test', {'field': (str, Ellipsis)}]
@@ -39,4 +39,4 @@ def register_action_outcls(func):
         action_outcls_registry[outcls_id] = out_cls
         return out_cls
 
-    return decorater
+    return decorator


### PR DESCRIPTION
## Summary
- rename inner function in `register_action_outcls` from `decorater` to `decorator`

## Testing
- `ruff check metagpt/actions/action_outcls_registry.py`
- `pytest tests/metagpt/actions/test_action_outcls_registry.py -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6851aab24458832b88f669944e112a20