### PR TITLE
Fix action graph imports and context fill bug

### DIFF
--- a/metagpt/actions/action_graph.py
+++ b/metagpt/actions/action_graph.py
@@ -7,7 +7,10 @@
 """
 from __future__ import annotations
 
-# from metagpt.actions.action_node import ActionNode
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from metagpt.actions.action_node import ActionNode
 
 
 class ActionGraph:
@@ -22,7 +25,7 @@ class ActionGraph:
         """Add a node to the graph"""
         self.nodes[node.key] = node
 
-    def add_edge(self, from_node: "ActionNode", to_node: "ActionNode"):
+    def add_edge(self, from_node: ActionNode, to_node: ActionNode):
         """Add an edge to the graph"""
         if from_node.key not in self.edges:
             self.edges[from_node.key] = []

--- a/metagpt/actions/action_node.py
+++ b/metagpt/actions/action_node.py
@@ -632,13 +632,15 @@ class ActionNode:
         if self.schema:
             schema = self.schema
 
+        context = self.compile(context=self.context, schema=schema, mode=mode, exclude=exclude)
+
         if mode == FillMode.CODE_FILL.value:
             result = await self.code_fill(context, function_name, timeout)
             self.instruct_content = self.create_class()(**result)
             return self
 
         elif mode == FillMode.XML_FILL.value:
-            context = self.xml_compile(context=self.context)
+            context = self.xml_compile(context=context)
             result = await self.xml_fill(context, images=images)
             self.instruct_content = self.create_class()(**result)
             return self


### PR DESCRIPTION
## Summary
- fix `ActionGraph` import references using TYPE_CHECKING
- compile fill context before passing to helper methods

## Testing
- `pytest -q tests/test_actions/test_action_node.py::test_fill_mode` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6851a6b3f24c832bb86fd8861f717603