### PR TITLE
Fix typo in comment

### DIFF
--- a/metagpt/utils/special_tokens.py
+++ b/metagpt/utils/special_tokens.py
@@ -1,4 +1,4 @@
 # token to separate different code messages in a WriteCode Message content
 MSG_SEP = "#*000*#"
-# token to seperate file name and the actual code text in a code message
+# token to separate file name and the actual code text in a code message
 FILENAME_CODE_SEP = "#*001*#"


### PR DESCRIPTION
## Summary
- correct "seperate" to "separate" in special_tokens

## Testing
- `ruff check metagpt/utils/special_tokens.py`
- `black --check metagpt/utils/special_tokens.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6851a971d1e4832b96201a83a01caa38