### PR TITLE
Fix type comparisons in action_node

### DIFF
--- a/metagpt/actions/action_node.py
+++ b/metagpt/actions/action_node.py
@@ -567,23 +567,23 @@ class ActionNode:
                 raw_value = match.group(1).strip()
                 field_type = field_types.get(field_name)
 
-                if field_type == str:
+                if field_type is str:
                     extracted_data[field_name] = raw_value
-                elif field_type == int:
+                elif field_type is int:
                     try:
                         extracted_data[field_name] = int(raw_value)
                     except ValueError:
                         extracted_data[field_name] = 0  # 或者其他默认值
-                elif field_type == bool:
+                elif field_type is bool:
                     extracted_data[field_name] = raw_value.lower() in ("true", "yes", "1", "on", "True")
-                elif field_type == list:
+                elif field_type is list:
                     try:
                         extracted_data[field_name] = eval(raw_value)
                         if not isinstance(extracted_data[field_name], list):
                             raise ValueError
                     except:
                         extracted_data[field_name] = []  # 默认空列表
-                elif field_type == dict:
+                elif field_type is dict:
                     try:
                         extracted_data[field_name] = eval(raw_value)
                         if not isinstance(extracted_data[field_name], dict):


### PR DESCRIPTION
## Summary
- fix type comparison logic in `ActionNode.fill` by using `is`

## Testing
- `ruff check metagpt/actions/action_node.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6851b26198a0832bb3d29a2cccc4623e