### PR TITLE
Fix Dockerfile apt options and devcontainer script

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,7 +1,9 @@
+#!/usr/bin/env bash
+
 # Step 1: Ensure that NPM is installed on your system. Then install mermaid-js.
 npm --version
 sudo npm install -g @mermaid-js/mermaid-cli
 
-# Step 2: Ensure that Python 3.9+ is installed on your system. You can check this by using:
+# Step 2: Ensure that Python 3.9+ is installed on your system.
 python --version
 pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM nikolaik/python-nodejs:python3.9-nodejs20-slim
 
 # Install Debian software needed by MetaGPT and clean up in one RUN command to reduce image size
 RUN apt update &&\
-    apt install -y libgomp1 git chromium fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 --no-install-recommends file &&\
+    apt install -y --no-install-recommends \
+        libgomp1 git chromium \
+        fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg \
+        fonts-kacst fonts-freefont-ttf libxss1 file &&\
     apt clean && rm -rf /var/lib/apt/lists/*
 
 # Install Mermaid CLI globally


### PR DESCRIPTION
## Summary
- fix Dockerfile apt install options order
- add bash shebang and newline to devcontainer postCreateCommand script
- make devcontainer script executable

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6851b6b0f498832bb78455309ff91f62